### PR TITLE
Add dynamic linking via pkg-config

### DIFF
--- a/feather/Cargo.toml
+++ b/feather/Cargo.toml
@@ -2,6 +2,7 @@
 name = "feather"
 version = "0.1.0"
 edition = "2024"
+build = "build.rs"
 
 [dependencies]
 rustypipe = "0.9.0"
@@ -14,6 +15,8 @@ tempfile = "3.16.0"
 libmpv2 = "4.1.0"
 dirs = "6.0.0"
 
+[build-dependencies]
+pkg-config = "0.3"
 
 [lib]
 name = "feather"

--- a/feather/build.rs
+++ b/feather/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    if pkg_config::probe_library("mpv").is_err() {
+        println!("cargo:warning=Could not find mpv via pkg-config. Make sure it is installed");
+    }
+}

--- a/feather_frontend/Cargo.lock
+++ b/feather_frontend/Cargo.lock
@@ -513,6 +513,7 @@ dependencies = [
  "bincode",
  "dirs",
  "libmpv2",
+ "pkg-config",
  "rustypipe",
  "serde",
  "sled",


### PR DESCRIPTION
#1 

This change allows the linker to just work (at least for macOS), rather than having to set paths before each build.

### Changes:
- add pkg-config as a dependency to handle dynamic linking
- add build script to check for mpv
- add build script & build-dep to feather manifest