### PR TITLE
Support for ctrl+c.

### DIFF
--- a/feather_frontend/src/main.rs
+++ b/feather_frontend/src/main.rs
@@ -150,11 +150,11 @@ impl App<'_> {
                                 Cell::from("Toggle between search input and results"),
                             ]),
                             Row::new(vec![
-                                Cell::from("Esc / Ctrl + C (Global)"),
+                                Cell::from("Esc / Ctrl + c (Global)"),
                                 Cell::from("Quit application"),
                             ]),
                             Row::new(vec![
-                                Cell::from("Esc / Ctrl + C (Non-Global)"),
+                                Cell::from("Esc / Ctrl + c (Non-Global)"),
                                 Cell::from("Switch to Global Mode"),
                             ]),
                             Row::new(vec![


### PR DESCRIPTION
This pull request modifies the `handle_global_keystrokes` method in `feather_frontend/src/main.rs` to detect the key combination Ctrl+C. 

I noticed that Feather is already supporting some vim keys such as j and k for navigation and personally I have the habit of pressing ctrl+c to return to normal/global mode. Also, with this new change, if you are in global mode and press ctrl+c the app will quit (the same as if esc was pressed) which I feel is very natural when it comes to terminal applications.

My changes to the handle global keystrokes matches ctrl+c to anywhere that esc would also be matched in an attempt to make them behave the same (similar to how j and k act similar to up and down). I also modified the help table row's that mention Esc to also show Ctrl + C although I'm not sure if that is necessary.

I tried my best to follow the same code style that I seen throughout the code base but of course I can always modify it if needed.

I did make sure to test my changes to make sure that nothing broke and everything works as expected. I went through each of the modes and then exiting them pressing ctrl+c then i made sure esc also still worked. I also checked to make sure that pressing 'c' by itself or 'ctrl' by itself didn't trigger the change. 

I see that in the `README.md` it mentions that further controls and keyboard shortcuts will be documented soon and that there is plans for a configuration file in the future so if this PR kind of gets ignored I understand. Feather looks really promising and I know that the maintainers are probably more concerned with more important features at the moment. I appreciate all the devs work!
- Kevin Barrios                            
                           